### PR TITLE
[fix] Put _HOST_TAR_X into .make.vars like the other platform variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ include .env
 	@echo _DOCKER_BASE_IMAGE_DEPS = $(shell find wp-ops/docker/wp-base -type f | sed 's/\n/ /g') >> $@
 	@echo _DOCKER_MGMT_IMAGE_DEPS = $(shell find wp-ops/docker/mgmt -type f | sed 's/\n/ /g') >> $@
 	@echo _DOCKER_HTTPD_IMAGE_DEPS = $(shell find wp-ops/docker/httpd -type f | sed 's/\n/ /g') >> $@
-
+	@echo _HOST_TAR_X = $(shell if [ "$$(uname -s)" = "Linux" ]; then echo -- tar -m --overwrite ; else echo tar; fi) >> $@
 
 m = $(notdir $(MAKE))
 .PHONY: help
@@ -146,12 +146,6 @@ checkout: \
   volumes/usrlocalbin
 
 git_clone = mkdir -p $(dir $@) || true; devscripts/ensure-git-clone.sh $(_GITHUB_BASE)$(strip $(1)) $@; touch $@
-
-ifeq ($(shell uname -s),Linux)
-_HOST_TAR_X := tar -m --overwrite
-else
-_HOST_TAR_X := tar
-endif
 
 volumes/usrlocalbin: .docker-all-images-built.stamp
 	mkdir $@ || true


### PR DESCRIPTION
Test like this:

```
rm .make.vars
touch .docker-all-images-built.stamp
make up
```
