### PR TITLE
[feature] Check out newly created github.com/epfl-si/wp-cli-polylang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ WP_CONTENT_DIR = volumes/wp/5/wp-content
 WP4_CONTENT_DIR = volumes/wp/4/wp-content
 JAHIA2WP_DIR = volumes/wp/jahia2wp
 WP_CLI_DIR = volumes/wp/wp-cli/vendor/epfl-si/wp-cli
+WP_CLI_POLYLANG_DIR = volumes/wp/wp-cli/vendor/cortneyray/wp-cli-polylang
 
 CTAGS_TARGETS_PYTHON = $(JAHIA2WP_DIR)/src \
   $(JAHIA2WP_DIR)/functional_tests \
@@ -144,6 +145,7 @@ checkout: \
   $(WP4_CONTENT_DIR)/themes/wp-theme-2018 \
   $(WP4_CONTENT_DIR)/themes/wp-theme-light \
   $(WP_CLI_DIR) \
+  $(WP_CLI_POLYLANG_DIR) \
   wp-ops \
   volumes/usrlocalbin
 
@@ -261,6 +263,9 @@ $(WP_CONTENT_DIR)/mu-plugins: $(WP_CONTENT_DIR)
 
 $(WP_CLI_DIR):
 	$(call git_clone, epfl-si/wp-cli)
+
+$(WP_CLI_POLYLANG_DIR):
+	$(call git_clone, epfl-si/wp-cli-polylang)
 
 wp-ops:
 	$(call git_clone, epfl-si/wp-ops)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,7 @@ services:
       - ./volumes/srv:/srv
       - ./volumes/wp:/wp
       - ./volumes/wp/wp-cli/vendor/epfl-si:/var/www/.wp-cli/packages/vendor/epfl-si
+      - ./volumes/wp/wp-cli/vendor/cortneyray:/var/www/.wp-cli/packages/vendor/cortneyray
       - .env:/srv/.env
       - ./volumes/usrlocalbin:/usr/local/bin
       - ./wp-ops:/wp-ops


### PR DESCRIPTION
https://github.com/epfl-si/wp-ops/commit/f2091c2d49ddde025e10c5e8f2852f4551b44024 retires the local copy of the `cortneyray/wp-cli-polylang` patched wp-cli plug-in, which was turned into a [proper GitHub fork](https://github.com/epfl-si/wp-cli-polylang) instead. Check out and use the latter as part of the wp-dev workspace.
