### PR TITLE
[feature] Install purchased assets from S3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,14 @@ _S3_INSTALL_AUTO_FLAGS = \
 	-@echo $(_S3_INSTALL_AUTO_FLAGS)
 
 .docker-base-image-built.stamp: wp-ops $(_DOCKER_BASE_IMAGE_DEPS)
+	@if PATH=$(_S3_SUITCASE_EYAML_PATH):$$PATH which eyaml; then : ; else \
+	  echo >&2 "eyaml command needed to decipher build-time secrets."; \
+	  echo >&2 "Please either install ruby and the hiera-eyaml gem,"; \
+	  echo >&2 "or deploy your Ansible suitcase: "; \
+	  echo >&2 ; \
+	  echo >&2 "   ./wp-ops/ansible/wpsible -t nothing"; \
+	fi
+
 	[ -d wp-ops/docker/wp-base ] && \
 	  docker build -t $(DOCKER_BASE_IMAGE_NAME) $(DOCKER_BASE_BUILD_ARGS) --build-arg INSTALL_AUTO_FLAGS="$(INSTALL_AUTO_FLAGS) $(_DEFAULT_INSTALL_AUTO_FLAGS)" wp-ops/docker/wp-base
 	touch $@


### PR DESCRIPTION
This pull request goes with https://github.com/epfl-si/wp-ops/pull/430.

We suffer from occasional build failures because of a BadZipFile error caused by wp-manager.epfl.ch truncating the downloads (for reasons yet unknown). To remediate this, we set up a new bucket on s3.epfl.ch and put our purchased software assets there (for the time being, the list consists of the wp-media-folder and wpforms plugins).

- Pass required --s3-* flags to `install-plugins-and-themes.py` via `--build-arg INSTALL_AUTO_FLAGS`
- Decrypt secrets from Keybase and EYAML (w/ poor man's Jinja parser in Perl)
- Give the operator a clue if no eyaml binary can be found
