### PR TITLE
[fix] source SMTP secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,6 +332,7 @@ SITE_DIR := /srv/test/wp-httpd/htdocs
 
 .PHONY: up
 up: checkout $(DOCKER_IMAGE_STAMPS) volumes/srv/test
+	$(source_smtp_secrets); \
 	docker-compose up -d
 	./devscripts/await-mysql-ready
 	$(MAKE) rootsite
@@ -377,6 +378,12 @@ gitpull:
 volumes/srv/test:
 	mkdir -p "$@"
 	chmod 1777 "$@"
+
+# SMTP secret
+define source_smtp_secrets
+	. /keybase/team/epfl_wp_test/service-noreply-wwp.sh; \
+	export SMTP_SECRET
+endef
 
 ######################## Development Tasks ########################
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
     # The `httpd` container only needs to know WP_ENV:
     environment:
       - WP_ENV=${WP_ENV}
+      - SMTP_SECRET=${SMTP_SECRET}
     ports:
       - "${WP_PORT_HTTP}:8080"
       - "${WP_PORT_HTTPS}:8443"


### PR DESCRIPTION
This fix allows to test 2867cfc9a27c85abab005051f2cf2fa09a41a98e locally 
(with wp-dev) and be able to send mail.