### PR TITLE
[fix] use of the Docker CLI (Compose V2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ help:
 	@echo '$(m) help           Show this message'
 	@echo
 	@echo '$(m) up             Start up a local WordPress instance'
-	@echo '                    with docker-compose for development.'
+	@echo '                    with docker compose for development.'
 	@echo '                    Be sure to review ../README.md for'
 	@echo '                    preliminary steps (entry in /etc/hosts,'
 	@echo '                    .env file and more)'
@@ -316,7 +316,7 @@ _S3_INSTALL_AUTO_FLAGS = \
 
 .docker-all-images-built.stamp: .docker-base-image-built.stamp wp-ops \
                                  $(_DOCKER_HTTPD_IMAGE_DEPS)
-	docker-compose build $(DOCKER_BUILD_ARGS)
+	docker compose build $(DOCKER_BUILD_ARGS)
 	touch $@
 
 .PHONY: docker-build
@@ -337,7 +337,7 @@ SITE_DIR := /srv/test/wp-httpd/htdocs
 .PHONY: up
 up: checkout $(DOCKER_IMAGE_STAMPS) volumes/srv/test
 	$(source_smtp_secrets); \
-	docker-compose up -d
+	docker compose up -d
 	./devscripts/await-mysql-ready
 	$(MAKE) rootsite
 	echo "If you have want to use the wp-gutenberg-epfl plugin or to dev on Gutenberg,"
@@ -377,11 +377,11 @@ rootsite:
 
 .PHONY: stop
 stop:
-	docker-compose stop
+	docker compose stop
 
 .PHONY: down
 down:
-	docker-compose down
+	docker compose down
 
 _find_git_depots := find . \( -path ./volumes/srv -prune -false \) -o -name .git -prune |xargs -n 1 dirname|grep -v 'ansible-deps-cache'
 .PHONY: gitstatus
@@ -426,7 +426,7 @@ tail-access:
 
 .PHONY: logs
 logs:
-	docker-compose logs -f --tail=5
+	docker compose logs -f --tail=5
 
 .PHONY: lnav
 lnav:

--- a/devscripts/functions.sh
+++ b/devscripts/functions.sh
@@ -12,7 +12,7 @@ die () {
 }
 
 dockermysql () {
-    local dockerbash="docker-compose exec -T db bash -c"
+    local dockerbash="docker compose exec -T db bash -c"
     case "$1" in
         mysql|mysqldump)
             local cmd="$1"; shift

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@
 # which ensures that all required images are built, and code
 # repositories are checked out.
 #
-# docker-compose automatically sources the .env file if it exists
+# docker compose automatically sources the .env file if it exists
 # (see https://docs.docker.com/compose/environment-variables/#the-env-file);
 # this is what makes the ${VARIABLE} expansions below work.
 


### PR DESCRIPTION
As stated in the compose documentation
(https://docs.docker.com/compose/reference/), from the end of June 2023 Compose V1 won’t be supported anymore and will be removed from all Docker Desktop versions. You can run Compose V2 by replacing the hyphen (-) with a space, using `docker compose`, instead of `docker-compose` and this is exactly what's it's intended in this commit.