### PR TITLE
[fix] Bypass permissions problems with `restic restore`

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ directory of this repo, run (for instance):
 SITE_ORIGINAL_URL=https://www.epfl.ch/campus/services/website/canari-wpforms/ \
 SITE_ANSIBLE_IDENTIFIER=www__campus__services__website__canari_wpforms \
 RESTORED_SITE_DIR_NAME=canari-wpforms \
-./local-restore-from-restic.sh
+./devscripts/local-restore-from-restic.sh
 ```
 
 
@@ -306,7 +306,7 @@ You can audit the development rig by yourselves if you type
 [Ansible suitcase]: https://github.com/epfl-si/ansible.suitcase
 [eyaml]: https://github.com/voxpupuli/hiera-eyaml
 [Keybase]: https://keybase.io
-[local-restore-from-restic.sh]: ./devscripts/local-resotre-from-restic.sh
+[local-restore-from-restic.sh]: ./devscripts/local-restore-from-restic.sh
 [`new-wp-site.sh`]: https://github.com/epfl-si/wp-ops/blob/master/docker/mgmt/new-wp-site.sh
 [wp-dev]: https://github.com/epfl-si/wp-dev
 [wp-ops]: https://github.com/epfl-si/wp-ops

--- a/devscripts/local-restore-from-restic.sh
+++ b/devscripts/local-restore-from-restic.sh
@@ -39,9 +39,8 @@ docker exec --user www-data -i ${_mgmt_container} bash -c "mkdir -p /srv/${WP_EN
 docker exec --user www-data -i ${_mgmt_container} bash -c "cd /srv/${WP_ENV}/wp-httpd/htdocs/${RESTORED_SITE_DIR_NAME}; new-wp-site --debug"
 
 # Restore the backup directly in the new site's folder
-restic -r s3:https://s3.epfl.ch/${S3_BUCKET_NAME}/backup/wordpresses/${SITE_ANSIBLE_IDENTIFIER}/files restore latest \
-            --include="/wp-content" \
-            --target ${scriptdir}/../volumes/srv/${WP_ENV}/wp-httpd/htdocs/${RESTORED_SITE_DIR_NAME}/
+restic -r s3:https://s3.epfl.ch/${S3_BUCKET_NAME}/backup/wordpresses/${SITE_ANSIBLE_IDENTIFIER}/files dump latest /wp-content \
+   | docker exec --user www-data -i ${_mgmt_container} tar -C/srv/${WP_ENV}/wp-httpd/htdocs/${RESTORED_SITE_DIR_NAME} -xpvf -
 
 # Import the DB
 docker exec --user www-data -i ${_mgmt_container} bash -c "wp --path=/srv/${WP_ENV}/wp-httpd/htdocs/${RESTORED_SITE_DIR_NAME} db import /srv/${WP_ENV}/${SITE_ANSIBLE_IDENTIFIER}-db-backup.sql"


### PR DESCRIPTION
Restore from within the mgmt container using a `restic dump | docker exec tar` pipeline, so that we don't have to deal with permissions as seen from outside the container.

Pair-programmed with @rosamaggi 