### PR TITLE
[simplify] `make MINIMAL=1`: no more manually-curated exclude list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,9 +296,7 @@ pull:
 	for image in $(_DOCKER_PULLED_IMAGES); do docker pull $$image; done
 	touch $@
 
-ifdef MINIMAL
-_DEFAULT_INSTALL_AUTO_FLAGS := --exclude=wp-media-folder --exclude=wpforms --exclude=wpforms-surveys-polls
-else
+ifndef MINIMAL
 _DEFAULT_INSTALL_AUTO_FLAGS = $(_S3_INSTALL_AUTO_FLAGS)   # Below
 endif
 


### PR DESCRIPTION
After https://github.com/epfl-si/wp-ops/pull/562 , simply omitting the S3 flags to `install-plugins-and-themes.py` does the trick of skipping any and all plugins hosted on S3.
