### PR TITLE
[feature] Make all git repositories “pushable”

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,8 @@ src:
 	# Copy the latest version of WordPress from the image
 	docker cp wp-php-4-wp-extractor:/wp/$(WP_MAJOR_VERSION)/. src
 	touch $@
+	# Ensure "epfl-si" repositories' remote URLs are SSH URL
+	./devscripts/ensure-git-ssh-url ./src
 
 _find_git_depots := find . \( -path ./volumes -prune -false \) -o -name .git -prune |xargs -n 1 dirname|grep -v 'ansible-deps-cache'
 .PHONY: git-status

--- a/devscripts/ensure-git-ssh-url
+++ b/devscripts/ensure-git-ssh-url
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Find all .git/config files in subdirectories
+find "$1" -type f -path '*/.git/config' | while read -r config_file; do
+    # Check if the file contains the URL to replace
+    if grep -q 'url = https://github.com/epfl-si/' "$config_file"; then
+        echo "Updating $config_file to use a SSH URL"
+        # Use sed to replace the URL
+        sed -i 's|url = https://github.com/epfl-si/|url = git@github.com:epfl-si/|g' "$config_file"
+    fi
+done
+
+echo "Checked that epfl-si repositories use an SSH URL."


### PR DESCRIPTION
This will change all remotes URL of "epfl-si" repositories to git@github.com: instead of https://github.com/