### PR TITLE
[feature] Add some observability on the wp-php container by adding a tracing stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ var/wp-data:
 
 .PHONY: stop
 stop: ## Stop the local WordPress instance
-	docker compose stop
+	docker compose --profile "*" stop
 
 .PHONY: rm
 rm: ## Remove the containers by name
@@ -248,7 +248,7 @@ rm: ## Remove the containers by name
 
 .PHONY: down
 down: ## Stop the local WordPress instance and delete its containers
-	docker compose down
+	docker compose --profile "*" down
 
 .PHONY: gutenberg
 gutenberg: ## Start the development server for Gutenberg
@@ -309,6 +309,17 @@ lnav:
 .PHONY: tail-sql
 tail-sql: ## Activate and follow the MariaDB general query log
 	./devscripts/mariadb-general-log tail
+
+
+########################################################################
+##@ Trace
+
+.PHONY: trace-up
+trace-up: ## Start the containers to provide tracing features
+	docker compose --profile observability up -d
+	@echo ""
+	@echo "To look at the generated traces,"
+	@echo "Open http://localhost:3000/explore, look under \"Query type\" > \"Search\" "
 
 
 ########################################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,7 +153,7 @@ services:
 
   grafana:
     profiles: [observability]
-    image: grafana/grafana:latest
+    image: grafana/grafana:12.4.1
     ports:
       - "3000:3000"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     container_name: wp-php
     build: wp-ops/docker/wordpress-php
     # https://quay-its.epfl.ch/repository/svc0041/wp-php
-    image: quay-its.epfl.ch/svc0041/wp-php:${WP_PHP_IMAGE_VERSION:-2026-068}
+    image: quay-its.epfl.ch/svc0041/wp-php:otel
     volumes:
       # src is created by Makefile:
       - ./src:/wp
@@ -56,12 +56,25 @@ services:
       organization: "EPFL / ISAS-FSD"
     environment:
       - OPDO_DIR=/tmp
+      ##
+      # Tracing
+      - OTEL_PHP_AUTOLOAD_ENABLED=true
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+      - OTEL_SERVICE_NAME=wp-php
+      - OTEL_RESOURCE_ATTRIBUTES="service.name=wp-php,service.environnment=development,service.namespace=local-dev"
+      # To only sample the 20%:
+      #- OTEL_TRACES_SAMPLER=parentbased_traceidratio
+      #- OTEL_TRACES_SAMPLER_ARG=0.2
+      # To activate debug:
+      #- OTEL_LOG_LEVEL=debug
+      #- OTEL_TRACES_EXPORTER=console
 
   nginx:
     container_name: wp-nginx
     build: wp-ops/docker/wordpress-nginx
     # https://quay-its.epfl.ch/repository/svc0041/wp-nginx
-    image: quay-its.epfl.ch/svc0041/wp-nginx:${WP_NGINX_IMAGE_VERSION:-2026-068}
+    image: quay-its.epfl.ch/svc0041/wp-nginx:2026-068
     ports:
       - 80:80
       - 443:443
@@ -111,6 +124,50 @@ services:
       maintainer: "isas-fsd@groupes.epfl.ch"
       organization: "EPFL / ISAS-FSD"
 
+  ###
+  # Observability
+  tempo:
+    profiles: [observability]
+    image: grafana/tempo:2.3.1
+    command: [ "-config.file=/etc/tempo.yaml" ]
+    volumes:
+      - ./observability/tempo/config.yaml:/etc/tempo.yaml
+      - tempo-data:/tmp/tempo/blocks
+      - tempo-wal:/tmp/tempo/wal
+    ports:
+      - "3200:3200"   # Tempo HTTP API
+      - "4327:4327"   # OTLP gRPC (internal use)
+      - "4328:4328"   # OTLP HTTP (internal use)
+
+  otel-collector:
+    profiles: [observability]
+    image: otel/opentelemetry-collector-contrib:latest
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./observability/otel-collector/config.yaml:/etc/otel-collector-config.yaml
+    ports:
+      - "4317:4317"   # OTLP gRPC (exposed to your apps)
+      - "4318:4318"   # OTLP HTTP (exposed to your apps)
+    depends_on:
+      - tempo
+
+  grafana:
+    profiles: [observability]
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    volumes:
+      - ./observability/grafana/datasources-tempo.yaml:/etc/grafana/provisioning/datasources/tempo.yaml
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      - tempo
+
 volumes:
    phpfpm-socket:
    mariadb-data:
+   grafana-data:
+   tempo-data:
+   tempo-wal:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,10 +59,10 @@ services:
       ##
       # Tracing
       - OTEL_PHP_AUTOLOAD_ENABLED=true
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
-      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
       - OTEL_SERVICE_NAME=wp-php
-      - OTEL_RESOURCE_ATTRIBUTES="service.name=wp-php,service.environnment=development,service.namespace=local-dev"
+      - OTEL_RESOURCE_ATTRIBUTES="service.name=wp-php,service.environment=development,service.namespace=local-dev"
       # To only sample the 20%:
       #- OTEL_TRACES_SAMPLER=parentbased_traceidratio
       #- OTEL_TRACES_SAMPLER_ARG=0.2

--- a/observability/grafana/datasources-tempo.yaml
+++ b/observability/grafana/datasources-tempo.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    isDefault: true

--- a/observability/otel-collector/config.yaml
+++ b/observability/otel-collector/config.yaml
@@ -18,9 +18,11 @@ exporters:
       max_elapsed_time: 30s
     sending_queue:
       enabled: false
+  debug:
+    verbosity: normal
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [otlp/tempo]
+      exporters: [otlp/tempo,debug]

--- a/observability/otel-collector/config.yaml
+++ b/observability/otel-collector/config.yaml
@@ -1,0 +1,26 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  otlp/tempo:
+    endpoint: tempo:4327
+    tls:
+      insecure: true
+    retry_on_failure:
+      enabled: true
+      initial_interval: 1s
+      max_interval: 5s
+      max_elapsed_time: 30s
+    sending_queue:
+      enabled: false
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp/tempo]

--- a/observability/tempo/config.yaml
+++ b/observability/tempo/config.yaml
@@ -1,0 +1,19 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4327"
+        http:
+          endpoint: "0.0.0.0:4328"
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /tmp/tempo/blocks
+    wal:
+      path: /tmp/tempo/wal


### PR DESCRIPTION
This requires a wp-php image with opentelemetry installed.

The usage of the tracing containers are optional, as set by docker compose profiles.

The setup:
wp-php -> Opentelemetry Collector -> Tempo -> Grafana